### PR TITLE
ch17202 - long text fix for option list in sharing modal

### DIFF
--- a/src/shared/components/Collaborator/styles.js
+++ b/src/shared/components/Collaborator/styles.js
@@ -6,6 +6,7 @@ export default makeStyles({
     alignItems: 'center',
   },
   imageContainer: {
+    minWidth: 30,
     width: 30,
     height: 30,
     overflow: 'hidden',

--- a/src/shared/components/SharingModal/components/MemberInput/MemberInput.js
+++ b/src/shared/components/SharingModal/components/MemberInput/MemberInput.js
@@ -137,6 +137,7 @@ const MemberInput = (props) => {
           fullWidth
           classes={{
             root: classes.autocomplete,
+            option: classes.option,
           }}
           onInputChange={(e) => {
             // There is a bug with <Autocomplete /> where sometimes the event is null

--- a/src/shared/components/SharingModal/components/MemberInput/styles.js
+++ b/src/shared/components/SharingModal/components/MemberInput/styles.js
@@ -16,4 +16,12 @@ export default makeStyles((theme) => ({
     margin: '8px 0 -8px 0',
     color: theme.palette.palette.red,
   },
+  option: {
+    '&&& p': {
+      textOverflow: 'ellipsis',
+      display: 'inline-block',
+      overflow: 'hidden',
+      width: 215,
+    },
+  },
 }));

--- a/src/shared/components/SharingModal/sharing-modal.stories.js
+++ b/src/shared/components/SharingModal/sharing-modal.stories.js
@@ -29,7 +29,7 @@ storiesOf(categoryName, module).add('default', () => {
       {
         id: 'morochroyce@gmail.com',
         mainText: 'Peter Adams',
-        secondaryText: 'morochroyce@gmail.com',
+        secondaryText: 'morochroyce@gmail.comaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
         imageSrc: 'https://cdn.theatlantic.com/thumbor/55coU3IJRzsQ16uvkFvYoLl3Pkc=/200x200/filters:format(png)/media/None/image/original.png',
         permissionsId: 'edit',
         isOwner: true,


### PR DESCRIPTION
Fixed bug with the options list in sharing modal.
The autocomplete seems to not work well with he Collaborators component. Added some css to fix it.

![image](https://user-images.githubusercontent.com/26363061/88103848-8d42e000-cb6f-11ea-8c3b-17e034621c84.png)
