### PR TITLE
fix scroll in FilesTable

### DIFF
--- a/src/shared/components/ObjectsTable/styles.js
+++ b/src/shared/components/ObjectsTable/styles.js
@@ -33,5 +33,7 @@ export default makeStyles((theme) => ({
   tableWrapper: {
     flexGrow: 1,
     padding: 6,
+    minHeight: 0,
+    overflow: 'auto',
   },
 }));


### PR DESCRIPTION
- fix scroll in objectsTable (show scroll next to table, instead scrolling whole app)
![image](https://user-images.githubusercontent.com/22597256/88540306-f9f82780-d012-11ea-8afb-78158c649f65.png)
