### PR TITLE
add share progress toast

### DIFF
--- a/src/UI/theme/palette/palette.js
+++ b/src/UI/theme/palette/palette.js
@@ -17,6 +17,7 @@ const blue4 = '#b2d3ff';
 const blue5 = '#e9e8f9';
 const red = '#ef6a6e';
 const yellow = '#FFD700';
+const green = '#00a83e';
 
 const palette = {
   black,
@@ -38,6 +39,7 @@ const palette = {
   blue5,
   red,
   yellow,
+  green,
 };
 
 export default palette;

--- a/src/events/add-items-subscribe.js
+++ b/src/events/add-items-subscribe.js
@@ -3,7 +3,7 @@ import {
   SET_UPLOAD_SUCCESS_STATE, SET_UPLOAD_ERROR_STATE,
 } from '@reducers/storage';
 import {
-  openModal, UPLOAD_PROGRESS_MODAL,
+  openModal, UPLOAD_PROGRESS_TOAST,
 } from '@shared/components/Modal/actions';
 
 import store from '../store';
@@ -30,7 +30,7 @@ const registerAddItemsSubscribeEvents = () => {
 };
 
 export const addItems = (payload) => {
-  const modalId = store.dispatch(openModal(UPLOAD_PROGRESS_MODAL));
+  const modalId = store.dispatch(openModal(UPLOAD_PROGRESS_TOAST));
   ipcRenderer.send(SUBSCRIBE_START_EVENT, { id: modalId, payload });
 };
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -118,6 +118,11 @@
     "dismiss": "Dismiss",
     "defaultMessage": "Upload in progress..."
   },
+  "sharingProgressModal": {
+    "message": "Shared <0>{{fileName}}",
+    "inProgress": "Sharing <0>{{fileName}}...",
+    "dismiss": "Close"
+  },
   "modals": {
     "sharingModal": {
       "to": "To",

--- a/src/shared/components/Modal/SharingProgress/index.js
+++ b/src/shared/components/Modal/SharingProgress/index.js
@@ -1,0 +1,90 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { faCheckCircle } from '@fortawesome/pro-solid-svg-icons/faCheckCircle';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Trans, useTranslation } from 'react-i18next';
+import Typography from '@ui/Typography';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import Grow from '@material-ui/core/Grow';
+import useStyles from './styles';
+
+const TRANSITION_TIMEOUT = 300;
+
+const SharingProgress = ({ closeModal }) => {
+  // TODO: replace it with reading state from redux (and keep also sharing progress)
+  const objects = useSelector((state) => (
+    state.storage.buckets.personal.objects.slice(0, 1) || []
+  ));
+  const isUploaded = false;
+  const allFolders = objects.filter((obj) => obj.type === 'folder');
+
+  const classes = useStyles();
+  const [timeoutId, setTimeoutId] = useState(null);
+  const { t } = useTranslation();
+
+  const onClickDismiss = () => {
+    if (!timeoutId) {
+      setTimeoutId(
+        setTimeout(closeModal, TRANSITION_TIMEOUT),
+      );
+    }
+  };
+
+  useEffect(() => {
+    if (isUploaded) {
+      setTimeoutId(
+        setTimeout(closeModal, TRANSITION_TIMEOUT),
+      );
+    }
+  }, [isUploaded]);
+
+  useEffect(() => () => clearTimeout(timeoutId), []);
+
+  const translationTitle = objects.length === 1
+    ? objects[0].name
+    : `${t(
+      'detailsPanel.foldersNumber',
+      { count: allFolders.length },
+    )}, ${t(
+      'detailsPanel.filesNumber',
+      { count: objects.length - allFolders.length },
+    )}`;
+
+  return (
+    <Grow in={!timeoutId} timeout={TRANSITION_TIMEOUT}>
+      <div className={classes.root}>
+        <div>
+          {isUploaded
+            ? <FontAwesomeIcon icon={faCheckCircle} className={classes.icon} />
+            : <CircularProgress size={14} className={classes.loader} />}
+          <Typography variant="body1" weight="medium" component="span">
+            <Trans
+              i18nKey={
+                `sharingProgressModal.${isUploaded ? 'message' : 'inProgress'}`
+              }
+              values={{ fileName: translationTitle }}
+              components={[<Box fontWeight="600" component="span" />]}
+            />
+          </Typography>
+        </div>
+        <Button
+          color="secondary"
+          className={classes.button}
+          onClick={onClickDismiss}
+          disableRipple
+        >
+          {t('sharingProgressModal.dismiss')}
+        </Button>
+      </div>
+    </Grow>
+  );
+};
+
+SharingProgress.propTypes = {
+  closeModal: PropTypes.func.isRequired,
+};
+
+export default SharingProgress;

--- a/src/shared/components/Modal/SharingProgress/styles.js
+++ b/src/shared/components/Modal/SharingProgress/styles.js
@@ -1,0 +1,27 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export default makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+    padding: '8px 15px',
+    backgroundColor: theme.palette.palette.white,
+    borderRadius: 4,
+    boxShadow: theme.palette.shadows.main,
+    overflow: 'hidden',
+  },
+  button: {
+    padding: 0,
+    fontSize: 14,
+  },
+  icon: {
+    marginRight: 10,
+    color: theme.palette.palette.green,
+    fontSize: 14,
+  },
+  loader: {
+    margin: '0 10px -2px 0',
+    color: theme.palette.palette.blue1,
+  },
+}));

--- a/src/shared/components/Modal/UploadProgress/index.js
+++ b/src/shared/components/Modal/UploadProgress/index.js
@@ -7,26 +7,18 @@ import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import Grow from '@material-ui/core/Grow';
 import useStyles from './styles';
-import { UPLOAD_PROGRESS_MODAL } from '../actions';
 
 const TRANSITION_TIMEOUT = 300;
 
 const UploadProgress = ({ id, closeModal }) => {
   const [timeoutId, setTimeoutId] = useState(null);
   const { t } = useTranslation();
-  const [
-    uploadProgressModals,
-    { completedFiles = 0, totalFiles = 0 },
-  ] = useSelector((state) => [
-    state.modals.filter((modal) => modal.type === UPLOAD_PROGRESS_MODAL),
-    state.storage.uploadsList[id] || {},
-  ]);
-  const orderNumber = uploadProgressModals.findIndex(
-    (modal) => modal.id === id,
-  );
+  const { completedFiles = 0, totalFiles = 0 } = useSelector((state) => (
+    state.storage.uploadsList[id] || {}
+  ));
+
   const classes = useStyles({
     progress: completedFiles / totalFiles || 0,
-    order: orderNumber,
   });
 
   const onClickDismiss = () => {

--- a/src/shared/components/Modal/UploadProgress/styles.js
+++ b/src/shared/components/Modal/UploadProgress/styles.js
@@ -1,18 +1,12 @@
 import { makeStyles } from '@material-ui/core/styles';
-import { DETAILS_PANEL_WIDTH } from '@shared/components/DetailsPanel/styles';
-import { SIDEBAR_WIDTH } from '@shared/components/Layout/components/Sidebar/styles';
 
 export default makeStyles((theme) => ({
   root: {
-    position: 'fixed',
-    left: SIDEBAR_WIDTH + 12,
-    right: DETAILS_PANEL_WIDTH + 12,
-    bottom: ({ order }) => 12 + 50 * order,
+    marginBottom: 12,
     backgroundColor: theme.palette.palette.white,
     borderRadius: 4,
     boxShadow: theme.palette.shadows.main,
     overflow: 'hidden',
-    zIndex: 1,
   },
   info: {
     display: 'flex',

--- a/src/shared/components/Modal/actions.js
+++ b/src/shared/components/Modal/actions.js
@@ -5,7 +5,8 @@ export const OPEN_MODAL = 'OPEN_MODAL';
 export const CLOSE_MODAL = 'CLOSE_MODAL';
 
 /* Modal Ids */
-export const UPLOAD_PROGRESS_MODAL = 'UPLOAD_PROGRESS_MODAL';
+export const UPLOAD_PROGRESS_TOAST = 'UPLOAD_PROGRESS_TOAST';
+export const SHARE_PROGRESS_TOAST = 'SHARE_PROGRESS_TOAST';
 export const SHARING_MODAL = 'SHARING_MODAL';
 
 /* Action creators */

--- a/src/shared/components/Modal/index.js
+++ b/src/shared/components/Modal/index.js
@@ -2,38 +2,56 @@ import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
 import UploadProgressModal from './UploadProgress';
+import SharingProgressModal from './SharingProgress';
 import SharingModal from './Sharing';
+import useStyles from './styles';
 
 import {
   closeModal as closeModalAction,
-  UPLOAD_PROGRESS_MODAL,
+  UPLOAD_PROGRESS_TOAST,
+  SHARE_PROGRESS_TOAST,
   SHARING_MODAL,
 } from './actions';
 
 const MODALS = {
-  [UPLOAD_PROGRESS_MODAL]: UploadProgressModal,
+  [UPLOAD_PROGRESS_TOAST]: UploadProgressModal,
+  [SHARE_PROGRESS_TOAST]: SharingProgressModal,
   [SHARING_MODAL]: SharingModal,
 };
 
+const getModalsComponents = (modals, dispatch) => modals.map(({ id, type, props }) => {
+  const ModalComponent = MODALS[type];
+  const closeModal = () => dispatch(closeModalAction(id));
+
+  return (
+    <ModalComponent
+      open
+      key={id}
+      closeModal={closeModal}
+      id={id}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
+    />
+  );
+});
+
+const isItToast = (modal) => modal.type.split('_').slice(-1)[0] === 'TOAST';
+
 const Modal = () => {
+  const classes = useStyles();
   const dispatch = useDispatch();
-  const modals = useSelector((state) => state.modals);
+  const allModals = useSelector((state) => state.modals);
+  const toasts = allModals.filter(isItToast).reverse();
+  const otherModals = allModals.filter((modal) => !isItToast(modal));
 
-  return modals.map(({ id, type, props }) => {
-    const ModalComponent = MODALS[type];
-    const closeModal = () => dispatch(closeModalAction(id));
-
-    return (
-      <ModalComponent
-        open
-        key={id}
-        closeModal={closeModal}
-        id={id}
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...props}
-      />
-    );
-  });
+  return (
+    <>
+      {getModalsComponents(otherModals, dispatch)}
+      <div className={classes.toastsContainer}>
+        {getModalsComponents(toasts, dispatch)}
+      </div>
+    </>
+  );
 };
 
 export default Modal;

--- a/src/shared/components/Modal/styles.js
+++ b/src/shared/components/Modal/styles.js
@@ -1,0 +1,13 @@
+import { makeStyles } from '@material-ui/core/styles';
+import { DETAILS_PANEL_WIDTH } from '@shared/components/DetailsPanel/styles';
+import { SIDEBAR_WIDTH } from '@shared/components/Layout/components/Sidebar/styles';
+
+export default makeStyles({
+  toastsContainer: {
+    position: 'fixed',
+    left: SIDEBAR_WIDTH + 12,
+    right: DETAILS_PANEL_WIDTH + 12,
+    bottom: 12,
+    zIndex: 1,
+  },
+});


### PR DESCRIPTION
Add share progress toast.
In progress:
![image](http://g.recordit.co/YOvZPedkNU.gif)

Completed:
![image](http://g.recordit.co/Wm0CJgsLvs.gif)

Also all modal which type ends with `_TOAST` will be displayed in dedicated container, to avoid overlapping (previously we were calculating bottom position (on `position: fixed`) from the window)
![image](http://g.recordit.co/qdZ6vEFyPk.gif)