### PR TITLE
Fix columns width

### DIFF
--- a/src/views/Storage/shared/getTableHeads.js
+++ b/src/views/Storage/shared/getTableHeads.js
@@ -4,15 +4,15 @@ import { IconsTooltip } from '@ui/Table';
 
 export default (t) => [
   {
-    width: '41%',
+    width: '40%',
     title: t('modules.storage.fileTable.head.name'),
   },
   {
-    width: '29%',
+    width: '20%',
     title: t('modules.storage.fileTable.head.size'),
   },
   {
-    width: 'auto',
+    width: '32%',
     title: t('modules.storage.fileTable.head.lastModified'),
   },
   {


### PR DESCRIPTION
## Changelog

- Fix `FileTable` columns width

<img width="1312" alt="Screen Shot 2020-09-01 at 12 37 02" src="https://user-images.githubusercontent.com/20387722/91881917-39d4af00-ec50-11ea-928a-72bcaaf5749b.png">
