### PR TITLE
Minor UI fixes

### DIFF
--- a/public/electron/events/mock-shared-object.js
+++ b/public/electron/events/mock-shared-object.js
@@ -1,7 +1,7 @@
 module.exports = {
   data: [
     {
-      path: '/Presentation-s.pptx',
+      path: 'Presentation-s.pptx',
       name: 'Presentation-s.pptx',
       isDir: false,
       created: '2020-08-25T10:17:16-04:00',
@@ -19,7 +19,7 @@ module.exports = {
       ],
     },
     {
-      path: '/image-s.jpg',
+      path: 'image-s.jpg',
       name: 'image-s.jpg',
       isDir: false,
       created: '2020-08-25T10:17:16-04:00',
@@ -37,7 +37,7 @@ module.exports = {
       ],
     },
     {
-      path: '/list_of_things-s.txt',
+      path: 'list_of_things-s.txt',
       name: 'list_of_things-s.txt',
       isDir: false,
       created: '2020-08-25T10:17:16-04:00',
@@ -55,7 +55,7 @@ module.exports = {
       ],
     },
     {
-      path: '/subfolder-s',
+      path: 'subfolder-s',
       name: 'subfolder-s',
       isDir: true,
       created: '2020-08-25T10:17:16-04:00',
@@ -68,7 +68,7 @@ module.exports = {
       members: [],
     },
     {
-      path: '/subfolder-s/.keep',
+      path: 'subfolder-s/.keep',
       name: '.keep',
       isDir: false,
       created: '2020-08-25T10:17:20-04:00',
@@ -81,7 +81,7 @@ module.exports = {
       members: [],
     },
     {
-      path: '/subfolder-s/List-s.xlsx',
+      path: 'subfolder-s/List-s.xlsx',
       name: 'List-s.xlsx',
       isDir: false,
       created: '2020-08-25T10:17:20-04:00',
@@ -94,7 +94,7 @@ module.exports = {
       members: [],
     },
     {
-      path: '/subfolder-s/sub-s',
+      path: 'subfolder-s/sub-s',
       name: 'sub-s',
       isDir: true,
       created: '2020-08-25T10:17:20-04:00',
@@ -107,7 +107,7 @@ module.exports = {
       members: [],
     },
     {
-      path: '/subfolder-s/sub-s/.keep',
+      path: 'subfolder-s/sub-s/.keep',
       name: '.keep',
       isDir: false,
       created: '2020-08-25T10:17:24-04:00',
@@ -120,7 +120,7 @@ module.exports = {
       members: [],
     },
     {
-      path: '/subfolder-s/sub-s/data-s.json',
+      path: 'subfolder-s/sub-s/data-s.json',
       name: 'data-s.json',
       isDir: false,
       created: '2020-08-25T10:17:24-04:00',
@@ -133,7 +133,7 @@ module.exports = {
       members: [],
     },
     {
-      path: '/subfolder-s/sub-s/key-s.txt',
+      path: 'subfolder-s/sub-s/key-s.txt',
       name: 'key-s.txt',
       isDir: false,
       created: '2020-08-25T10:17:24-04:00',

--- a/src/shared/components/Modal/Settings/get-content.js
+++ b/src/shared/components/Modal/Settings/get-content.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Security, Account, Usage } from './views';
+import { Security, Account } from './views';
 
 export default ({
   t,
@@ -26,14 +26,15 @@ export default ({
   //   title: t('modals.settings.notifications.title'),
   //   content: <div>notifications</div>,
   // },
-  {
-    id: 'usage',
-    default: defaultItem === 'usage',
-    title: t('modals.settings.usage.title'),
-    content: (
-      <Usage />
-    ),
-  },
+  // TODO: uncomment after integration
+  // {
+  //   id: 'usage',
+  //   default: defaultItem === 'usage',
+  //   title: t('modals.settings.usage.title'),
+  //   content: (
+  //     <Usage />
+  //   ),
+  // },
   // TODO: uncomment after integration
   // {
   //   id: 'referrals',

--- a/src/views/Storage/SharedBy/index.js
+++ b/src/views/Storage/SharedBy/index.js
@@ -1,9 +1,10 @@
 import React, { useEffect } from 'react';
 import get from 'lodash/get';
+import Typography from '@ui/Typography';
+import { useTranslation } from 'react-i18next';
 import { fetchSharedObjects } from '@events/objects';
 import { useHistory, matchPath } from 'react-router-dom';
 
-import Breadcrumbs from './components/Breadcrumbs';
 import { FileTable, HeaderNav } from '../shared/components';
 import useStyles from './styles';
 
@@ -11,6 +12,7 @@ const SharedWithMeView = () => {
   const classes = useStyles();
   const history = useHistory();
   const { location } = history;
+  const { t } = useTranslation();
 
   const match = matchPath(location.pathname, { path: '/storage/shared-by/*' });
   const prefix = get(match, 'params.0', '') || '';
@@ -23,7 +25,9 @@ const SharedWithMeView = () => {
     <div className={classes.root}>
       <HeaderNav />
       <div className={classes.breadcrumbs}>
-        <Breadcrumbs />
+        <Typography variant="h6" className={classes.title} weight="medium">
+          {t('navigation.shared-by')}
+        </Typography>
       </div>
       <FileTable
         prefix={prefix}


### PR DESCRIPTION
## Changelog

- Removed usage metrics from settings modal
- Removed old breadcrumb bucket from sharing view
- Updated mock response for shared files (removed initial `/` on file path)

<img width="1312" alt="Screen Shot 2020-09-04 at 16 51 25" src="https://user-images.githubusercontent.com/20387722/92283888-ea4fe680-eece-11ea-99d8-8c6fbef5da38.png">
<img width="1312" alt="Screen Shot 2020-09-04 at 16 51 34" src="https://user-images.githubusercontent.com/20387722/92283894-ee7c0400-eece-11ea-822b-862c2d1aa291.png">


