### PR TITLE
fixed notifcation timestamps

### DIFF
--- a/src/UI/Notification/NotificationItem/NotificationItem.js
+++ b/src/UI/Notification/NotificationItem/NotificationItem.js
@@ -24,6 +24,7 @@ const NotificationItem = (props) => {
     status,
     highlighted,
   } = props;
+
   const FILE_STACK_MAX = 5;
 
   const classes = useStyles({


### PR DESCRIPTION
fixing timestamp for notifications since BE timestamp is in seconds not ms

![image](https://user-images.githubusercontent.com/26363061/92733283-7f2a6800-f345-11ea-8acc-2082693b9ba8.png)
