### PR TITLE
add min height to rainbow field to expand on full height, fix bug wit…

### DIFF
--- a/src/shared/components/Dropzone/index.js
+++ b/src/shared/components/Dropzone/index.js
@@ -60,7 +60,7 @@ const Dropzone = ({
       {...getRootProps()}
       className={classes.root}
     >
-      <div ref={wrapperNode}>
+      <div ref={wrapperNode} className={classes.wrapper}>
         {isDragActive && (
           <div
             className={classes.rainbowField}

--- a/src/shared/components/Dropzone/styles.js
+++ b/src/shared/components/Dropzone/styles.js
@@ -5,10 +5,15 @@ export const headHeight = 27;
 
 export default makeStyles({
   root: {
+    display: 'flex',
     position: 'relative', // to set boundaries for rainbow field during drag'n'drop
+    minHeight: '100%',
     '&:focus': {
       outline: 'none',
     },
+  },
+  wrapper: {
+    minHeight: '100%',
   },
   rainbowField: {
     position: 'absolute',

--- a/src/views/Storage/Files/components/EmptyState/styles.js
+++ b/src/views/Storage/Files/components/EmptyState/styles.js
@@ -14,11 +14,10 @@ export default makeStyles((theme) => ({
     margin: '8px 0 7px',
   },
   plusIcon: {
-    position: 'relative',
-    top: 2,
     width: 14,
     height: 14,
     padding: 2,
+    marginBottom: -2,
     backgroundColor: theme.palette.palette.white,
     borderRadius: '50%',
     boxShadow: '0 0 9px 0 rgba(222, 222, 222, 0.8)',


### PR DESCRIPTION
- add min height to rainbow field to expand on full height
- fix bug with plus icon (part of the table placeholder) visible over the rainbow field when there is no files


![](http://g.recordit.co/AoIUymkyyf.gif)