### PR TITLE
pre-fetch linked addresses for listing Torus integrations in settings

### DIFF
--- a/src/shared/components/Modal/Settings/views/Security/index.js
+++ b/src/shared/components/Modal/Settings/views/Security/index.js
@@ -15,7 +15,7 @@ import MessageBox from '@ui/MessageBox';
 import { faShieldAlt } from '@fortawesome/pro-regular-svg-icons/faShieldAlt';
 import { useTheme } from '@material-ui/core/styles';
 import { useSelector, useDispatch } from 'react-redux';
-import { getLinkedAddresses, addLinkedAddress } from '@events';
+import { addLinkedAddress } from '@events';
 import { useTorusSdk } from '@utils';
 import { LINKED_ADDRESSES_ACTION_TYPES } from '@reducers/linked-addresses';
 
@@ -53,10 +53,6 @@ const Security = ({ t }) => {
     reduxState.user,
     reduxState.linkedAddresses,
   ]);
-
-  useEffect(() => {
-    getLinkedAddresses();
-  }, []);
 
   const handleOpenModal = (event) => {
     event.preventDefault();

--- a/src/views/Storage/index.js
+++ b/src/views/Storage/index.js
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   Route,
   Switch,
   Redirect,
   useRouteMatch,
 } from 'react-router-dom';
+import { getLinkedAddresses } from '@events';
 
 import Layout from '@shared/components/Layout';
 
@@ -18,6 +19,11 @@ import useStyles from './styles';
 const Storage = () => {
   const classes = useStyles();
   const match = useRouteMatch();
+
+  // pre-fetching data for Settings
+  useEffect(() => {
+    getLinkedAddresses();
+  }, []);
 
   return (
     <Layout>


### PR DESCRIPTION
After discussing with Royce, we will pre-fetch the linked addresses instead of showing a skeleton loader in the settings.