### PR TITLE
skip password modal if torus integration

### DIFF
--- a/public/electron/events/keys.js
+++ b/public/electron/events/keys.js
@@ -94,7 +94,9 @@ const registerKeysEvents = (mainWindow) => {
 
   ipcMain.on(TEST_KEYS_BY_PASSPHRASE_AND_SIGN_OUT_EVENT, async (_, payload) => {
     try {
-      await spaceClient.testKeysPassphrase(payload);
+      if (payload.passphrase) {
+        await spaceClient.testKeysPassphrase(payload);
+      }
       await spaceClient.deleteKeyPair();
 
       mainWindow.webContents.send(TEST_KEYS_BY_PASSPHRASE_AND_SIGN_OUT_SUCCESS_EVENT);

--- a/src/events/keys.js
+++ b/src/events/keys.js
@@ -125,7 +125,7 @@ export const backupKeysByPassphrase = (payload) => {
  * @param {string} payload.uuid
  * @param {string} payload.passphrase
  */
-export const testKeys = (payload) => {
+export const testKeysAndDelete = (payload = {}) => {
   store.dispatch({
     type: SIGNOUT_ACTION_TYPES.ON_SIGNOUT,
   });

--- a/src/shared/components/Modal/SignoutConfirmation/index.js
+++ b/src/shared/components/Modal/SignoutConfirmation/index.js
@@ -13,7 +13,7 @@ import { faSpinner } from '@fortawesome/pro-regular-svg-icons/faSpinner';
 
 import BaseModal from '@ui/BaseModal';
 import Typography from '@ui/Typography';
-import { testKeys } from '@events';
+import { testKeysAndDelete } from '@events';
 import { USER_ACTION_TYPES } from '@reducers/user';
 import { SIGNOUT_ACTION_TYPES } from '@reducers/auth/signout';
 
@@ -71,7 +71,7 @@ const SignoutConfirmation = ({ closeModal }) => {
       <Box my={2}>
         <form
           id="password-form"
-          onSubmit={() => testKeys({
+          onSubmit={() => testKeysAndDelete({
             uuid: user.uuid,
             passphrase: password,
           })}
@@ -107,7 +107,7 @@ const SignoutConfirmation = ({ closeModal }) => {
           variant="contained"
           form="password-form"
           disabled={signoutState.loading}
-          onClick={() => testKeys({
+          onClick={() => testKeysAndDelete({
             uuid: user.uuid,
             passphrase: password,
           })}


### PR DESCRIPTION
We now skip the password confirmation modal on sign out when there is a torus integration. We also skip asking for password even if the user has a username+password as long as he has 1 torus integration

![Peek 2020-11-15 17-04](https://user-images.githubusercontent.com/26363061/99198173-cf1e1480-2764-11eb-8d24-aad45293d511.gif)
