### PR TITLE
Fix date in list view

### DIFF
--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -1,7 +1,7 @@
 import moment from 'moment-timezone';
 
 const formatDate = (date) => (
-  moment(date).tz(moment.tz.guess()).format('MMM d, YYYY')
+  moment(date).tz(moment.tz.guess()).format('MMM D, YYYY')
 );
 
 export default formatDate;

--- a/src/views/Storage/shared/RenderRow.js
+++ b/src/views/Storage/shared/RenderRow.js
@@ -33,7 +33,7 @@ const RenderRow = ({ row }) => {
       </TableCell>
       <TableCell>
         <Typography variant="body1" color="secondary" noWrap>
-          {moment(row.lastModified).format('MMM d, YYYY hh:mm:ss A z')}
+          {moment(row.lastModified).format('MMM D, YYYY hh:mm:ss A z')}
           {/* ^ just for testing, after POC should be used line below */}
           {/* {formatMonthDayYear(row.lastModified)} */}
         </Typography>


### PR DESCRIPTION
Fixed date formatting according to moment js docs (https://momentjs.com/docs/#/parsing/string-format/). It was previously displaying the day number (e.g. monday = 1, tuesday =2) instead of the actual date.

[ch19942]