### PR TITLE
fix number of members

### DIFF
--- a/src/reducers/storage/bucket.js
+++ b/src/reducers/storage/bucket.js
@@ -118,7 +118,7 @@ export default (state = DEFAULT_STATE, action) => {
                 ? action.payload.selected
                 : obj.selected,
               members,
-              shareAmount: members.length,
+              shareAmount: Math.max(1, members.length),
               // sometimes updates shareAmount = 0, because daemon is sending empty members list
             };
           }

--- a/src/reducers/storage/bucket.js
+++ b/src/reducers/storage/bucket.js
@@ -118,7 +118,7 @@ export default (state = DEFAULT_STATE, action) => {
                 ? action.payload.selected
                 : obj.selected,
               members,
-              shareAmount: Math.max(1, members.length),
+              shareAmount: Math.max(1, members.length, obj.shareAmount),
               // sometimes updates shareAmount = 0, because daemon is sending empty members list
             };
           }

--- a/src/utils/object-presenter.js
+++ b/src/utils/object-presenter.js
@@ -45,7 +45,7 @@ const objectPresenter = (obj = {}, isRootDir = false) => {
     ipfsHash: get(obj, 'ipfsHash'),
     isAvailableInSpace: backupCount > 0,
     sourceBucket: sourceBucket || bucket,
-    shareAmount: members.length,
+    shareAmount: Math.max(1, members.length),
   };
 };
 


### PR DESCRIPTION
Fix issue - over the first couple of seconds/minutes after upload the file daemon is returning empty array of members, without even the user. And after that time the user appears in the list, this is fix to make sure that there is never 0 members (it breaks calculation with sharing - adding new members later)