### PR TITLE
Mateuszwalendzik/ch20561/fix minor issue with rainbow field during

### DIFF
--- a/src/UI/Table/components/TableRow/styles.js
+++ b/src/UI/Table/components/TableRow/styles.js
@@ -22,6 +22,9 @@ export default makeStyles((theme) => ({
       borderRadius: 4,
       backgroundColor: theme.palette.palette.white,
     },
+    '& > *': {
+      zIndex: 1,
+    },
   },
   hover: {},
 }));

--- a/src/UI/Table/components/TableRow/styles.js
+++ b/src/UI/Table/components/TableRow/styles.js
@@ -22,9 +22,6 @@ export default makeStyles((theme) => ({
       borderRadius: 4,
       backgroundColor: theme.palette.palette.white,
     },
-    '& > *': {
-      zIndex: 1,
-    },
   },
   hover: {},
 }));

--- a/src/shared/components/Dropzone/index.js
+++ b/src/shared/components/Dropzone/index.js
@@ -4,6 +4,9 @@ import { useDropzone } from 'react-dropzone';
 import PropTypes from 'prop-types';
 import useStyles, { rowHeight, headHeight } from './styles';
 
+const RAINBOW_BORDER_WIDTH = 2;
+const X_MARGINS = 12;
+
 const Dropzone = ({
   children,
   objectsList,
@@ -74,6 +77,38 @@ const Dropzone = ({
     bottom: wrapperHeight.current - (headHeight + (rowNumber + 1) * rowHeight),
   } : {};
 
+  const getSvg = (overrideSvgProps) => {
+    const defaultHeight = Math.max(objectsList.length * rowHeight, wrapperHeight.current);
+
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={`calc(100% - ${X_MARGINS}px)`}
+        height={`${defaultHeight + RAINBOW_BORDER_WIDTH / 2}px`}
+        className={classes.rainbowField}
+      >
+        <linearGradient id="gradient" x1="0%" y1="25%" x2="100%" y2="75%">
+          <stop offset="18%" stopColor="#ed55eb" />
+          <stop offset="42%" stopColor="#17e0d8" />
+          <stop offset="59%" stopColor="#00ffc2" />
+          <stop offset="81%" stopColor="#ffec06" />
+        </linearGradient>
+        <rect
+          fill="transparent"
+          y={rainbowFieldStyles.top ? rainbowFieldStyles.top : headHeight}
+          x={`${RAINBOW_BORDER_WIDTH / 2}px`}
+          width={`calc(100% - ${RAINBOW_BORDER_WIDTH}px)`}
+          height={rainbowFieldStyles.top ? rowHeight : defaultHeight - headHeight}
+          rx="6"
+          ry="6"
+          style={{ transition: 'y ease .17s, height ease .17s' }}
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...overrideSvgProps}
+        />
+      </svg>
+    );
+  };
+
   return (
     <div
       // eslint-disable-next-line react/jsx-props-no-spreading
@@ -81,11 +116,16 @@ const Dropzone = ({
       className={classes.root}
     >
       <div ref={wrapperNode} className={classes.wrapper}>
-        {isDragActive && (
-          <div
-            className={classes.rainbowField}
-            style={rainbowFieldStyles}
-          />
+        {(isDragActive || true) && (
+          <>
+            {getSvg({
+              fill: 'url(#gradient)',
+            })}
+            {getSvg({
+              stroke: 'url(#gradient)',
+              strokeWidth: RAINBOW_BORDER_WIDTH,
+            })}
+          </>
         )}
         {/* eslint-disable-next-line react/jsx-props-no-spreading */}
         <input {...getInputProps()} />

--- a/src/shared/components/Dropzone/index.js
+++ b/src/shared/components/Dropzone/index.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import useStyles, { rowHeight, headHeight } from './styles';
 
 const RAINBOW_BORDER_WIDTH = 2;
-const X_MARGINS = 12;
 
 const Dropzone = ({
   children,
@@ -83,7 +82,7 @@ const Dropzone = ({
     return (
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        width={`calc(100% - ${X_MARGINS}px)`}
+        width={`calc(100% - ${RAINBOW_BORDER_WIDTH}px)`}
         height={`${defaultHeight + RAINBOW_BORDER_WIDTH / 2}px`}
         className={classes.rainbowField}
       >
@@ -116,7 +115,7 @@ const Dropzone = ({
       className={classes.root}
     >
       <div ref={wrapperNode} className={classes.wrapper}>
-        {(isDragActive || true) && (
+        {isDragActive && (
           <>
             {getSvg({
               fill: 'url(#gradient)',

--- a/src/shared/components/Dropzone/index.js
+++ b/src/shared/components/Dropzone/index.js
@@ -118,10 +118,10 @@ const Dropzone = ({
         {isDragActive && (
           <>
             {getSvg({
-              fill: 'url(#gradient)',
+              fill: 'url(#dropzone-gradient)',
             })}
             {getSvg({
-              stroke: 'url(#gradient)',
+              stroke: 'url(#dropzone-gradient)',
               strokeWidth: RAINBOW_BORDER_WIDTH,
             })}
           </>

--- a/src/shared/components/Dropzone/index.js
+++ b/src/shared/components/Dropzone/index.js
@@ -86,7 +86,7 @@ const Dropzone = ({
         height={`${defaultHeight + RAINBOW_BORDER_WIDTH / 2}px`}
         className={classes.rainbowField}
       >
-        <linearGradient id="gradient" x1="0%" y1="25%" x2="100%" y2="75%">
+        <linearGradient id="dropzone-gradient" x1="0%" y1="25%" x2="100%" y2="75%">
           <stop offset="18%" stopColor="#ed55eb" />
           <stop offset="42%" stopColor="#17e0d8" />
           <stop offset="59%" stopColor="#00ffc2" />

--- a/src/shared/components/Dropzone/sample.svg
+++ b/src/shared/components/Dropzone/sample.svg
@@ -1,0 +1,9 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='100%' height='100%'>
+      <linearGradient id='gradient' gradientTransform='rotate(134)'>
+        <stop offset='18%' stop-color='#ed55eb'/>
+        <stop offset='42%' stop-color='#17e0d8'/>
+        <stop offset='59%' stop-color='#00ffc2'/>
+        <stop offset='81%' stop-color='#ffec06'/>
+      </linearGradient>
+      <rect stroke='url(#gradient)' stroke-width='10' fill='transparent' x='10' y='10' width='calc(100% - 25px)' height='calc(100% - 25px)' rx='20' ry='20'/>
+    </svg>

--- a/src/shared/components/Dropzone/styles.js
+++ b/src/shared/components/Dropzone/styles.js
@@ -1,14 +1,12 @@
+/* eslint-disable quotes */
 import { makeStyles } from '@material-ui/core/styles';
 
 export const rowHeight = 36;
 export const headHeight = 39;
 
-const RAINBOW_BORDER_WIDTH = 2;
-
 export default makeStyles({
   root: {
     display: 'flex',
-    position: 'relative', // to set boundaries for rainbow field during drag'n'drop
     minHeight: '100%',
     '&:focus': {
       outline: 'none',
@@ -18,22 +16,13 @@ export default makeStyles({
     minHeight: '100%',
   },
   rainbowField: {
+    pointerEvents: 'none',
     position: 'absolute',
-    background: 'linear-gradient(134deg, #ed55eb 18%, #17e0d8 42%, #00ffc2 59%, #ffec06 81%)',
-    backgroundRepeat: 'no-repeat',
-    borderRadius: 6,
-    top: headHeight - 2 * RAINBOW_BORDER_WIDTH,
-    right: -RAINBOW_BORDER_WIDTH,
-    bottom: -RAINBOW_BORDER_WIDTH,
-    left: -RAINBOW_BORDER_WIDTH,
-    padding: RAINBOW_BORDER_WIDTH,
-    transition: 'top ease .17s, bottom ease .17s',
-    '&:before': {
-      content: '""',
-      display: 'block',
-      height: '100%',
-      backgroundColor: 'rgba(255, 255, 255, 0.9)',
-      borderRadius: 4,
+    opacity: 0.1,
+    zIndex: 1,
+    '& + &': {
+      zIndex: 2,
+      opacity: 1,
     },
   },
 });

--- a/src/shared/components/Dropzone/styles.js
+++ b/src/shared/components/Dropzone/styles.js
@@ -13,11 +13,13 @@ export default makeStyles({
     },
   },
   wrapper: {
+    position: 'relative',
     minHeight: '100%',
   },
   rainbowField: {
     pointerEvents: 'none',
     position: 'absolute',
+    top: 0,
     opacity: 0.1,
     zIndex: 1,
     '& + &': {

--- a/src/shared/components/Dropzone/styles.js
+++ b/src/shared/components/Dropzone/styles.js
@@ -21,9 +21,8 @@ export default makeStyles({
     position: 'absolute',
     top: 0,
     opacity: 0.1,
-    zIndex: 1,
     '& + &': {
-      zIndex: 2,
+      zIndex: 1,
       opacity: 1,
     },
   },


### PR DESCRIPTION
Change the way of rainbow field worked, now it will be two elements, one is background (which is under the table) and another is border (which is above the table). Previously that wasn't possible because we had one element, and it couldn't  be at the same time below and above the table.