### PR TITLE
Ch20659/double row click fix

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -11,3 +11,4 @@ export { default as getShortAddress } from './get-short-address';
 export { default as useTorusSdk } from './use-torus-sdk';
 export { default as useWsChallenge } from './use-ws-challenge';
 export { default as getTabulations } from './get-tabulations';
+export { default as useDoubleClick } from './use-double-click';

--- a/src/utils/use-double-click.js
+++ b/src/utils/use-double-click.js
@@ -1,0 +1,39 @@
+import { useRef, useEffect } from 'react';
+
+const useDoubleClick = ({
+  singleClick,
+  doubleClick,
+  delay = 250,
+}) => {
+  const clickAmount = useRef(0);
+  const timer = useRef(null);
+
+  useEffect(() => (
+    () => {
+      if (timer) {
+        clearTimeout(timer.current);
+      }
+    }
+  ),
+  []);
+
+  const onClick = (event) => {
+    clickAmount.current += 1;
+    if (timer.current) {
+      return;
+    }
+    timer.current = setTimeout(() => {
+      if (clickAmount.current >= 2) {
+        doubleClick(event);
+      } else {
+        singleClick(event);
+      }
+      clickAmount.current = 0;
+      timer.current = null;
+    }, delay);
+  };
+
+  return onClick;
+};
+
+export default useDoubleClick;

--- a/src/views/Storage/shared/RenderRow/index.js
+++ b/src/views/Storage/shared/RenderRow/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -30,9 +30,36 @@ const RenderRow = ({
   handleDoubleRowClick,
   rowClasses,
 }) => {
+  const clickAmount = useRef(0);
+  const timer = useRef(null);
   const location = useLocation();
   const classes = useStyles({ progress: 0.4, rowIndex });
   const { t } = useTranslation();
+
+  useEffect(() => (
+    () => {
+      if (timer) {
+        clearTimeout(timer.current);
+      }
+    }
+  ),
+  []);
+
+  const onClick = (event) => {
+    clickAmount.current += 1;
+    if (timer.current) {
+      return;
+    }
+    timer.current = setTimeout(() => {
+      if (clickAmount.current >= 2) {
+        handleDoubleRowClick({ row })(event);
+      } else {
+        handleRowClick({ rowIndex })(event);
+      }
+      clickAmount.current = 0;
+      timer.current = null;
+    }, 250);
+  };
 
   const getSizeIcon = () => {
     if (row.isUploading) {
@@ -114,9 +141,8 @@ const RenderRow = ({
         [rowClasses.selected]: row.selected,
         [rowClasses.error]: row.error && !row.isUploading,
       })}
-      onClick={handleRowClick({ row, rowIndex })}
       onContextMenu={handleRowRightClick({ row })}
-      onDoubleClick={handleDoubleRowClick({ row })}
+      onClick={onClick}
       component={
         ({ children, ...rowProps }) => (
           <Tooltip

--- a/src/views/Storage/shared/RenderRow/index.js
+++ b/src/views/Storage/shared/RenderRow/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -7,7 +7,7 @@ import { useLocation } from 'react-router-dom';
 import Typography from '@material-ui/core/Typography';
 import { useTranslation } from 'react-i18next';
 import { TableCell, FileNameCell, TableRow } from '@ui/Table';
-import { formatBytes, getTabulations } from '@utils';
+import { formatBytes, getTabulations, useDoubleClick } from '@utils';
 import getHoverMenuItems from '@shared/components/ObjectsTable/utils/get-hover-menu';
 import hoverMenuItemOnClick from '@shared/components/ObjectsTable/utils/hover-menu-on-click';
 
@@ -30,36 +30,14 @@ const RenderRow = ({
   handleDoubleRowClick,
   rowClasses,
 }) => {
-  const clickAmount = useRef(0);
-  const timer = useRef(null);
   const location = useLocation();
   const classes = useStyles({ progress: 0.4, rowIndex });
   const { t } = useTranslation();
 
-  useEffect(() => (
-    () => {
-      if (timer) {
-        clearTimeout(timer.current);
-      }
-    }
-  ),
-  []);
-
-  const onClick = (event) => {
-    clickAmount.current += 1;
-    if (timer.current) {
-      return;
-    }
-    timer.current = setTimeout(() => {
-      if (clickAmount.current >= 2) {
-        handleDoubleRowClick({ row })(event);
-      } else {
-        handleRowClick({ rowIndex })(event);
-      }
-      clickAmount.current = 0;
-      timer.current = null;
-    }, 250);
-  };
+  const onClick = useDoubleClick({
+    singleClick: handleRowClick({ rowIndex }),
+    doubleClick: handleDoubleRowClick({ row }),
+  });
 
   const getSizeIcon = () => {
     if (row.isUploading) {

--- a/src/views/Storage/shared/ShareRenderRow/SharedRenderRow.js
+++ b/src/views/Storage/shared/ShareRenderRow/SharedRenderRow.js
@@ -1,10 +1,10 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import classnames from 'classnames';
 import get from 'lodash/get';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import { getTabulations } from '@utils';
+import { getTabulations, useDoubleClick } from '@utils';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -32,8 +32,6 @@ const ShareRenderRow = ({
   handleDoubleRowClick,
   rowClasses,
 }) => {
-  const clickAmount = useRef(0);
-  const timer = useRef(null);
   const location = useLocation();
   const members = get(row, 'members', []) || [];
   const [userAddress, identities] = useSelector((state) => [state.user.address, state.identities]);
@@ -51,30 +49,10 @@ const ShareRenderRow = ({
     }
   }, []);
 
-  useEffect(() => (
-    () => {
-      if (timer) {
-        clearTimeout(timer.current);
-      }
-    }
-  ),
-  []);
-
-  const onClick = (event) => {
-    clickAmount.current += 1;
-    if (timer.current) {
-      return;
-    }
-    timer.current = setTimeout(() => {
-      if (clickAmount.current >= 2) {
-        handleDoubleRowClick({ row })(event);
-      } else {
-        handleRowClick({ rowIndex })(event);
-      }
-      clickAmount.current = 0;
-      timer.current = null;
-    }, 250);
-  };
+  const onClick = useDoubleClick({
+    singleClick: handleRowClick({ rowIndex }),
+    doubleClick: handleDoubleRowClick({ row }),
+  });
 
   return (
     <TableRow


### PR DESCRIPTION
There was a problem in which onClick couldn't coexist with onDoubleClick since one of those would not work.
So instead of using onDoubleClick, I made a hook that determines whether we should execute the single click logic or the double click logic and ties it to a single onClick function.